### PR TITLE
give more flexiblity around cert signing

### DIFF
--- a/generate_certs.sh
+++ b/generate_certs.sh
@@ -3,7 +3,6 @@
 # set PATH to find all binaries
 PATH=$PATH:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 export TOPDIR=$(realpath $(dirname $0))
-export PARMS="$@"
 
 # Static defaults
 LTHN_PREFIX=/home/lthn
@@ -11,10 +10,16 @@ LTHN_PREFIX=/home/lthn
 # General usage help
 usage() {
    echo 
-   echo "To generate root CA with your own CA CN and password, and generate a VPN server certificate. Other options are optional if already having keys"
-   echo $0 "--ca [--generate-ca] [--with-cn commonname] [--with-capass pass] [--generate-dh] [--generate_tls_auth]"
+   echo "To generate root CA"
+   echo $0 "--ca [--with-cacn commonname --with-capass pass] [--generate-dh] [--generate-tls-auth]"
    echo
-   echo "To generate root CA and server certificates using defaults"
+   echo "To generate server certificate"
+   echo $0 "--server [--with-servercn commonname --with-serverpass pass] [--generate-dh] [--generate-tls-auth]"
+   echo
+   echo "To generate client certificate"
+   echo $0 "--client [--with-clientcn commonname --with-capass pass] [--generate-dh] [--generate-tls-auth]"
+   echo
+   echo "To generate root CA, one server and one client certificate using defaults"
    echo $0 "--defaults"
    echo
    exit
@@ -60,7 +65,8 @@ summary() {
         exit 1
     fi
 
-    echo "Lethean VPN CA, Server Certificates, DH and TLS-Auth keys generated."
+    echo "Lethean certificate(s) and/or key(s) generated."
+    echo
     echo "sudo bin:     $SUDO_BIN"
     echo "Openssl bin:  $OPENSSL_BIN"
     echo "Openvpn bin:  $OPENVPN_BIN"
@@ -71,18 +77,18 @@ summary() {
 }
 
 
-# Specify configuration for root CA and how it is generated
+# Specify configuration for local root CA and how it is generated
 generate_ca() {
     local prefix="$1"
     local cn="$2"
-    echo "Generating CA $cn"
+    echo "Generating CA Certificate (cn=$cn)"
     cd $prefix || exit 2
-    mkdir -p private certs csr newcerts || exit 2
+    mkdir -p private/client certs/client csr/client newcerts || exit 2
     touch index.txt
     echo -n 00 >serial
-    "${OPENSSL_BIN}" genrsa -aes256 -out private/ca.key.pem -passout pass:$cert_pass 4096
+    "${OPENSSL_BIN}" genrsa -aes256 -out private/ca.key.pem -passout pass:$ca_pass 4096
     chmod 400 private/ca.key.pem
-    "${OPENSSL_BIN}" req -config $TOPDIR/openvpn/conf/ca.cfg -batch -subj "/CN=$cn" -passin pass:$cert_pass \
+    "${OPENSSL_BIN}" req -config $TOPDIR/openvpn/conf/ca.cfg -batch -subj "/CN=$cn" -passin pass:$ca_pass \
       -key private/ca.key.pem \
       -new -x509 -days 7300 -sha256 -extensions v3_ca \
       -out certs/ca.cert.pem
@@ -92,25 +98,50 @@ generate_ca() {
     fi
 }
 
-# Specify how server keys are generated and signed with CA
-generate_crt() {
-    local name="$1"
+# Specify how server keys are generated and signed with local CA
+generate_server() {
+    local prefix="$1"
     local cn="$2"
-    echo "Generating crt (name=$name,cn=$cn)"
+    echo "Generating Server Certificate (cn=$cn)"
+    cd $prefix || exit 2
     "${OPENSSL_BIN}" genrsa -aes256 \
-      -out private/$name.key.pem -passout pass:$cert_pass 4096
-    chmod 400 private/$name.key.pem
-    "${OPENSSL_BIN}" req -config $TOPDIR/openvpn/conf/ca.cfg -batch -subj "/CN=$cn" -passin "pass:$cert_pass" \
-      -key private/$name.key.pem \
-      -new -sha256 -out csr/$name.csr.pem
-    "${OPENSSL_BIN}" ca -batch -config $TOPDIR/openvpn/conf/ca.cfg -subj "/CN=$cn" -passin "pass:$cert_pass" \
+      -out private/"$cn".key.pem -passout pass:$server_pass 4096
+    chmod 400 private/"$cn".key.pem
+    "${OPENSSL_BIN}" req -config $TOPDIR/openvpn/conf/ca.cfg -batch -subj "/CN=$cn" -passin "pass:$server_pass" \
+      -key private/"$cn".key.pem \
+      -new -sha256 -out csr/"$cn".csr.pem
+    "${OPENSSL_BIN}" ca -batch -config $TOPDIR/openvpn/conf/ca.cfg -subj "/CN=$cn" -passin "pass:$server_pass" \
       -extensions server_cert -days 375 -notext -md sha256 \
-      -in csr/$name.csr.pem \
-      -out certs/$name.cert.pem
-    (cat certs/ca.cert.pem certs/$name.cert.pem; openssl rsa -passin "pass:$cert_pass" -text <private/$name.key.pem) >certs/$name.all.pem
-    (cat certs/$name.cert.pem; openssl rsa -passin "pass:$cert_pass" -text <private/$name.key.pem) >certs/$name.both.pem
-    if ! [ -f certs/$name.cert.pem ]; then
-        echo "Error generating cert $name! See messages above."
+      -in csr/"$cn".csr.pem \
+      -out certs/"$cn".cert.pem
+    (cat certs/ca.cert.pem certs/"$cn".cert.pem; openssl rsa -passin "pass:$server_pass" -text <private/"$cn".key.pem) >certs/"$cn".all.pem
+    (cat certs/"$cn".cert.pem; openssl rsa -passin "pass:$server_pass" -text <private/"$cn".key.pem) >certs/"$cn".both.pem
+    if ! [ -f certs/"$cn".cert.pem ]; then
+        echo "Error generating cert $cn! See messages above."
+        exit 2
+    fi
+}
+
+# Specify how client keys are generated and signed with local CA
+generate_client() {
+    local prefix="$1"
+    local cn="$2"
+    echo "Generating Client Certificate (cn=$cn)"
+    cd $prefix || exit 2
+    "${OPENSSL_BIN}" genrsa -aes256 \
+      -out private/client/"$cn".key.pem -passout pass:$client_pass 2048
+    chmod 400 private/client/"$cn".key.pem
+    "${OPENSSL_BIN}" req -config $TOPDIR/openvpn/conf/ca.cfg -batch -subj "/CN=$cn" -passin "pass:$client_pass" \
+      -key private/client/"$cn".key.pem \
+      -new -sha256 -out csr/client/"$cn".csr.pem
+    "${OPENSSL_BIN}" ca -batch -config $TOPDIR/openvpn/conf/ca.cfg -subj "/CN=$cn" -passin "pass:$client_pass" \
+      -extensions usr_cert -days 375 -notext -md sha256 \
+      -in csr/client/"$cn".csr.pem \
+      -out certs/client/"$cn".cert.pem
+    (cat certs/ca.cert.pem certs/client/"$cn".cert.pem; openssl rsa -passin "pass:$client_pass" -text <private/client/"$cn".key.pem) >certs/client/"$cn".all.pem
+    (cat certs/client/"$cn".cert.pem; openssl rsa -passin "pass:$client_pass" -text <private/client/"$cn".key.pem) >certs/client/"$cn".both.pem
+    if ! [ -f certs/client/"$cn".cert.pem ]; then
+        echo "Error generating cert $cn! See messages above."
         exit 2
     fi
 }
@@ -149,17 +180,33 @@ while [[ $# -gt 0 ]]; do
         shift
     ;;
     --with-capass)
-        cert_pass="$2"
+        ca_pass="$2"
         shift
         shift
     ;;
-    --with-cn)
-        cert_cn="$2"
+    --with-cacn)
+        ca_cn="$2"
         shift
         shift
     ;;
-    --generate-ca)
-        generate_ca=1
+    --with-serverpass)
+        server_pass="$2"
+        shift
+        shift
+    ;;
+    --with-servercn)
+        server_cn="$2"
+        shift
+        shift
+    ;;
+    --with-clientpass)
+        client_pass="$2"
+        shift
+        shift
+    ;;
+    --with-clientcn)
+        client_cn="$2"
+        shift
         shift
     ;;
     --generate-dh)
@@ -172,16 +219,28 @@ while [[ $# -gt 0 ]]; do
     ;;
     --ca)
         generate_ca=1
-        cert_key_copy=1
+        shift
+    ;;
+    --server)
+        generate_server=1
+        shift
+    ;;
+    --client)
+        generate_client=1
         shift
     ;;
     --defaults)
-        cert_pass="1234"
-        cert_cn="Lethean VPN Server"
+        ca_pass="1234"
+        ca_cn="Lethean Exit Node Root CA"
+        server_pass="1234"
+        server_cn="Lethean_VPN_Server"
+        client_pass="1234"
+        client_cn="Lethean_VPN_Client"
         generate_ca=1
+        generate_server=1
+        generate_client=1
         generate_dh=1
         generate_tls_auth=1
-        cert_key_copy=1
         shift
     ;;
     *)
@@ -192,64 +251,112 @@ while [[ $# -gt 0 ]]; do
 esac
 done
 
-# Incomplete command message to user
-if [ -z "$generate_ca" ]; then
-    echo "You must select which parts to configure".
-    $0 -h
-    exit 1
-fi
-
 # Make directories for creation and moving generate keys
 mkdir -p build/etc
-mkdir -p etc/ca
+mkdir -p etc/ca/certs
+mkdir -p etc/ca/private
+mkdir -p etc/ca/certs/client
+mkdir -p etc/ca/private/client
 
 # Where files will eventually live
 sysconf_dir=${LTHN_PREFIX}/etc/
 ca_dir=${LTHN_PREFIX}/etc/ca/
 
-# Generate CA, sign server certificate and copy into desired folder
-mkdir -p build
+# Abort Root CA certificate creation if already exists.
+if [ -n "$generate_ca" ] && [ -f build/etc/ca/index.txt ]; then
+    echo "CA already exists. Aborting."
+    exit 2
+fi
+
+# Generate CA and place into desired folder
 if [ -n "$generate_ca" ] && ! [ -f build/etc/ca/index.txt ]; then
-    export cert_pass cert_cn
-    if [ -z "$cert_pass" ] || [ -z "$cert_cn" ] ; then
-        echo "You must specify --with-capass yourpassword --with_cn CN!"
+    export ca_pass ca_cn
+    if [ -z "$ca_pass" ] || [ -z "$ca_cn" ] ; then
+        echo "You must specify --with-capass yourpassword --with_cacn CN!"
         exit 2
     fi
-    if [ "$cert_pass" = "1234" ]; then
+    if [ "$ca_pass" = "1234" ]; then
     	echo "Generating with default password!"
     fi
     (
     rm -rf build/etc/ca
     mkdir -p build/etc/ca
-    generate_ca build/etc/ca/ "$cert_cn"
-    generate_crt openvpn "$cert_cn"
+    generate_ca build/etc/ca/ "$ca_cn"
     )
+    cp build/etc/ca/certs/ca.cert.pem etc/ca/certs/
 fi
 
-# Copy CA and signed certificates into desired folders
-if [ -n "$cert_key_copy" ]; then
-    if ! [ -f etc/ca/index.txt ]; then
-        if [ -f ./build/etc/ca/index.txt ]; then
-            cp -R build/etc/ca/* etc/ca/
-        else
-            echo "CA directory $LTHN_PREFIX/etc/ca/ not prepared! You should generate by configure or use your own CA!"
-        fi
+# Abort server certificate creation if duplicate CN certificate already exists.
+if [ -n "$generate_server" ] && [ -f build/etc/ca/certs/"$server_cn".cert.pem ]; then
+    echo "Server certificate "$server_cn" already exists. Aborting."
+    exit 2
+fi
+
+# Generate server certificate using our local CA and copy into desired folder
+if [ -n "$generate_server" ] && ! [ -f build/etc/ca/certs/"$server_cn".cert.pem ]; then
+    export server_pass server_cn
+    if [ -z "$server_pass" ] || [ -z "$server_cn" ] ; then
+        echo "You must specify --with-serverpass yourpassword --with_servercn CN!"
+        exit 2
     fi
+    if [ "$server_pass" = "1234" ]; then
+    	echo "Generating with default password!"
+    fi
+    (
+    generate_server build/etc/ca/ "$server_cn"
+    )
+    cp build/etc/ca/certs/"$server_cn"* etc/ca/certs/
+    cp build/etc/ca/private/"$server_cn"* etc/ca/private/
+fi
+
+# Abort client certificate creation if duplicate CN certificate already exists.
+if [ -n "$generate_client" ] && [ -f build/etc/ca/certs/client/$client_cn.cert.pem ]; then
+    echo "Client certificate "$client_cn" already exists. Aborting."
+    exit 2
+fi
+
+# Generate client certificate using our local CA and copy into desired folder
+if [ -n "$generate_client" ] && ! [ -f build/etc/ca/certs/client/$client_cn.cert.pem ]; then
+    export client_pass client_cn
+    if [ -z "$client_pass" ] || [ -z "$client_cn" ] ; then
+        echo "You must specify --with-clientpass yourpassword --with_clientcn CN!"
+        exit 2
+    fi
+    if [ "$client_pass" = "1234" ]; then
+    	echo "Generating with default password!"
+    fi
+    (
+    generate_client build/etc/ca/ "$client_cn"
+    )
+    cp build/etc/ca/certs/client/"$client_cn"* etc/ca/certs/client/
+    cp build/etc/ca/private/client/"$client_cn"* etc/ca/private/client/
+fi
+
+# Abort DH key creation if already exists.
+if [ -n "$generate_dh" ] && [ -f build/etc/dhparam.pem ]; then
+    echo "DH key already exists. Aborting."
+    exit 2
 fi
 
 # Generate and copy DH key to desired folder
-if [ -n "$generate_dh" ]; then
+if [ -n "$generate_dh" ] && ! [ -f build/etc/dhparam.pem ]; then
     if ! [ -f build/etc/dhparam.pem ]; then 
         "$OPENSSL_BIN" dhparam -out build/etc/dhparam.pem 2048
-        cp build/etc/dhparam.pem $LTHN_PREFIX/etc/
+        cp build/etc/dhparam.pem etc/
     fi
 fi
 
+# Abort tls-auth key creation if already exists.
+if [ -n "$generate_tls_auth" ] && [ -f build/etc/ta.key ]; then
+    echo "TLS auth key already exists. Aborting."
+    exit 2
+fi
+
 # Generate and copy tls-auth key to desired folder
-if [ -n "$generate_tls_auth" ]; then
+if [ -n "$generate_tls_auth" ] && ! [ -f build/etc/ta.key ]; then
     if ! [ -f build/etc/ca/ta.key ]; then 
-      "$OPENVPN_BIN" --genkey secret build/etc/ta.key
-      cp build/etc/ta.key $LTHN_PREFIX/etc/
+        "$OPENVPN_BIN" --genkey secret build/etc/ta.key
+        cp build/etc/ta.key etc/
     fi
 fi
 


### PR DESCRIPTION
Doco to follow for usage.
All options tested successfully.
Presently one known issue exists when switching using --defaults signing first off, then using --server or --client options to sign further on. The process however works.

If starting with use of --ca, --server, --client and others, no issues exist at present from my observations.
openvpn config file change to follow referencing all certificate paths 

Usage options updated to below:

```
To generate root CA
--ca [--with-cacn commonname --with-capass pass] [--generate-dh] [--generate-tls-auth]
 
To generate server certificate
--server [--with-servercn commonname --with-serverpass pass] [--generate-dh] [--generate-tls-auth]

To generate client certificate
--client [--with-clientcn commonname --with-capass pass] [--generate-dh] [--generate-tls-auth]"

To generate root CA, one server and one client certificate using defaults
--defaults
```